### PR TITLE
ci(publish): create GitHub pre-release after PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,20 +14,22 @@ jobs:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     if: >-
-      ${{ 
-        github.event_name == 'push' || 
-        (github.event_name == 'workflow_run' && 
-         github.event.workflow_run.conclusion == 'success' && 
+      ${{
+        github.event_name == 'push' ||
+        (github.event_name == 'workflow_run' &&
+         github.event.workflow_run.conclusion == 'success' &&
          !startsWith(github.event.workflow_run.head_commit.message, 'Bump version:'))
       }}
     environment: pypi
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: read
+      contents: write  # required for creating GitHub releases
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -39,3 +41,23 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${{ github.ref_name }}"
+          else
+            TAG=$(git describe --tags --abbrev=0)
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - name: Create GitHub pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          prerelease: true
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name == 'push' ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
         (github.event_name == 'workflow_run' &&
          github.event.workflow_run.conclusion == 'success' &&
          !startsWith(github.event.workflow_run.head_commit.message, 'Bump version:'))
@@ -48,7 +48,7 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAG="${{ github.ref_name }}"
           else
-            TAG=$(git describe --tags --abbrev=0)
+            TAG=$(git describe --tags --abbrev=0 --match 'v*')
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved tag: $TAG"


### PR DESCRIPTION
Adds a final step to `.github/workflows/publish.yml` that creates a GitHub
release (marked **pre-release**) for the tag that was just published to PyPI.

## What changed

- `permissions.contents: read` → `write` (needed to create releases).
- Checkout now uses `fetch-depth: 0` so `git describe` can resolve the tag on
  the `workflow_run` trigger path (where `github.ref` is `main`, not the tag).
- New **Resolve tag** step:
  - On `push` to `v*` tag → uses `github.ref_name`.
  - On `workflow_run` from Bump Version → uses `git describe --tags --abbrev=0`.
- New **Create GitHub pre-release** step using `softprops/action-gh-release@v2`:
  - `prerelease: true`
  - `generate_release_notes: true` (auto notes from PRs/commits since the last tag)
  - `files: dist/*` (attaches the same wheel + sdist that went to PyPI)

The release step runs **after** PyPI publish, so a failed publish will not
create a release.

## Summary by Sourcery

Automate creation of a GitHub pre-release whenever a package is successfully published to PyPI.

CI:
- Update the publish workflow permissions to allow creating GitHub releases and perform a full-depth checkout so tags are available.
- Add steps to resolve the appropriate release tag and create a GitHub pre-release with generated notes after a successful PyPI publish.